### PR TITLE
Исправлена синтаксическая ошибка с фигурными скобками

### DIFF
--- a/PHPCadesCPCertificate.cpp
+++ b/PHPCadesCPCertificate.cpp
@@ -62,10 +62,12 @@ PHP_METHOD(CPCertificate, HasPrivateKey) {
         (certificate_obj *)((char *)zobj - XtOffsetOf(certificate_obj, zobj));
 
     HR_ERRORCHECK_RETURN(obj->m_pCppCadesImpl->HasPrivateKey(&has));
-    if (has)
+    if (has) {
         RETURN_TRUE;
-    else
+    }
+    else {
         RETURN_FALSE;
+    }
 }
 
 PHP_METHOD(CPCertificate, IsValid) {


### PR DESCRIPTION
Возможно, это проблема именно моей версии компилятора, но я поймал эту ошибку, что компилятор ругается на "else без if", но так или иначе думаю, что это исправление не помешает коду.

