### PR TITLE
Совместимость с PHP 8.5

### DIFF
--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -115,7 +115,7 @@
         wchar_t buff[14];                                                                    \
         swprintf(buff, 14, L" (0x%08X)", err);                                               \
         message.Append(buff);                                                                \
-        zend_throw_exception(zend_exception_get_default(), CW2A(message, CP_UTF8), err);     \
+        zend_throw_exception(zend_ce_exception, CW2A(message, CP_UTF8), err);                \
         RETURN_FALSE;                                                                        \
     } while (0)
 


### PR DESCRIPTION
Изменил вызов `zend_exception_get_default()` на `zend_ce_exception` в `stdafx.h`

`zend_exception_get_default()` помечена как deprecated с PHP 7.0, в PHP 8.5 её не стало:
https://github.com/php/php-src/blob/PHP-7.0/Zend/zend_exceptions.h#L48-L49
https://github.com/php/php-src/blob/PHP-8.5/Zend/zend_exceptions.h